### PR TITLE
Fixed issue where blocks that require a higher tier hammer are deleted

### DIFF
--- a/common/src/main/java/pro/mikey/justhammers/HammerItem.java
+++ b/common/src/main/java/pro/mikey/justhammers/HammerItem.java
@@ -125,6 +125,10 @@ public class HammerItem extends DiggerItem {
             if (pos == blockPos || removedPos.contains(pos) || !canDestroy(targetState, level, pos)) {
                 continue;
             }
+            // Skips any blocks that require a higher tier hammer
+            if (!actualIsCorrectToolForDrops(targetState)) {
+                continue;
+            }
 
             // Throw event out there and let mods block us breaking this block
             EventResult eventResult = BlockEvent.BREAK.invoker().breakBlock(level, pos, targetState, (ServerPlayer) livingEntity, null);


### PR DESCRIPTION
This change prevents blocks in the mining radius that require a higher tier hammer from being deleted, they are instead just ignored.

This change also makes it so hammers only work on blocks that require a pickaxe, this is logically how they should work anyway.